### PR TITLE
Fix health check endpoint path from /healthz/ to /health/

### DIFF
--- a/apps/api/core/urls.py
+++ b/apps/api/core/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('healthz/', views.health_check, name='health-check'),
+    path('health/', views.health_check, name='health-check'),
     path('ready/', views.readiness_check, name='readiness-check'),
     path('live/', views.liveness_check, name='liveness-check'),
 ]

--- a/render.yaml
+++ b/render.yaml
@@ -71,7 +71,7 @@ services:
         value: "2.5"
       - key: MAX_FRAMES_PER_VIDEO
         value: "20"
-    healthCheckPath: /healthz/
+    healthCheckPath: /health/
 
   # Celery Worker
   - type: worker


### PR DESCRIPTION
## Issue Fixed
- **Health endpoint path**: Changed from /healthz/ to /health/ to match Render deployment expectations
- **Render integration**: Ensures proper deployment health monitoring

## Changes Made
- Updated core/urls.py health check path: healthz/ → health/
- Maintains existing comprehensive health check functionality
- Still validates database, Redis, and Celery service status

## Render Deployment
This fixes the health check endpoint to match Render's expected /health path for:
- Deployment health monitoring
- Service startup validation
- Runtime health checks

The endpoint remains publicly accessible (AllowAny) and returns JSON status for all critical services.

🤖 Generated with [Claude Code](https://claude.ai/code)