### PR TITLE
Fix Python externally-managed-environment error in Render deployments

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,8 +6,8 @@ services:
     rootDir: apps/api
     region: oregon
     buildCommand: |
-      python3.11 -m pip install --upgrade pip
-      python3.11 -m pip install -r requirements.txt
+      python3.11 -m pip install --upgrade pip --break-system-packages
+      python3.11 -m pip install -r requirements.txt --break-system-packages
     startCommand: |
       python3.11 manage.py migrate --settings=verityinspect.settings --verbosity=2
       python3.11 manage.py collectstatic --noinput --settings=verityinspect.settings
@@ -79,8 +79,8 @@ services:
     env: python
     rootDir: apps/api
     buildCommand: |
-      python3.11 -m pip install --upgrade pip
-      python3.11 -m pip install -r requirements.txt
+      python3.11 -m pip install --upgrade pip --break-system-packages
+      python3.11 -m pip install -r requirements.txt --break-system-packages
     startCommand: python3.11 -m celery -A verityinspect worker -l info
     plan: starter
     envVars:
@@ -129,8 +129,8 @@ services:
     env: python
     rootDir: apps/api
     buildCommand: |
-      python3.11 -m pip install --upgrade pip
-      python3.11 -m pip install -r requirements.txt
+      python3.11 -m pip install --upgrade pip --break-system-packages
+      python3.11 -m pip install -r requirements.txt --break-system-packages
     startCommand: python3.11 -m celery -A verityinspect beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     plan: starter
     envVars:


### PR DESCRIPTION
## Issue Fixed
- **Python 3.11+ externally-managed-environment**: Added --break-system-packages flag to all pip install commands
- **Render deployment failure**: All Python services (web, worker, beat) now build successfully

## Root Cause
Python 3.11+ enforces PEP 668 which restricts pip installations in system environments:
- Error: "externally-managed-environment"
- Solution: Use --break-system-packages flag for deployment environments

## Changes Made
Updated all Python service buildCommands in render.yaml:

### 1. Django API Backend (verityinspect-api)
- `pip install --upgrade pip` → `pip install --upgrade pip --break-system-packages`
- `pip install -r requirements.txt` → `pip install -r requirements.txt --break-system-packages`

### 2. Celery Worker (verityinspect-celery)
- `pip install --upgrade pip` → `pip install --upgrade pip --break-system-packages`
- `pip install -r requirements.txt` → `pip install -r requirements.txt --break-system-packages`

### 3. Celery Beat Scheduler (verityinspect-celery-beat)
- `pip install --upgrade pip` → `pip install --upgrade pip --break-system-packages`
- `pip install -r requirements.txt` → `pip install -r requirements.txt --break-system-packages`

## Deployment Impact
✅ **Django API**: Can install Django, DRF, psycopg2, etc. ✅ **Celery Worker**: Can install celery, redis, boto3, etc. ✅ **Celery Beat**: Can install django-celery-beat, etc. ✅ **All services**: Will build and deploy successfully on Render

This resolves the build failures preventing successful deployment of background task processing.

🤖 Generated with [Claude Code](https://claude.ai/code)