### PR TITLE
Add comprehensive debugging for Celery module not found error

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -79,8 +79,17 @@ services:
     env: python
     rootDir: apps/api
     buildCommand: |
+      echo "Python version: $(python3.11 --version)"
+      echo "Pip version: $(python3.11 -m pip --version)"
+      echo "Current directory: $(pwd)"
+      echo "Requirements file exists: $(ls -la requirements.txt)"
       python3.11 -m pip install --upgrade pip --break-system-packages
-      python3.11 -m pip install -r requirements.txt --break-system-packages
+      python3.11 -m pip install -r requirements.txt --break-system-packages --verbose
+      echo "Celery installed check:"
+      python3.11 -c "import sys; print('Python path:', sys.path)"
+      python3.11 -c "import celery; print(f'Celery version: {celery.__version__}')"
+      echo "Pip list:"
+      python3.11 -m pip list | grep celery
     startCommand: python3.11 -m celery -A verityinspect worker -l info
     plan: starter
     envVars:
@@ -129,8 +138,13 @@ services:
     env: python
     rootDir: apps/api
     buildCommand: |
+      echo "Python version: $(python3.11 --version)"
+      echo "Current directory: $(pwd)"
       python3.11 -m pip install --upgrade pip --break-system-packages
-      python3.11 -m pip install -r requirements.txt --break-system-packages
+      python3.11 -m pip install -r requirements.txt --break-system-packages --verbose
+      echo "Celery installed check:"
+      python3.11 -c "import celery; print(f'Celery version: {celery.__version__}')"
+      python3.11 -m pip list | grep celery
     startCommand: python3.11 -m celery -A verityinspect beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     plan: starter
     envVars:


### PR DESCRIPTION
## Issue Investigation
- **Celery Import Error**: "No module named celery" despite being in requirements.txt
- **Root Cause Unknown**: Need to debug Python environment and package installation

## Debugging Added
### Build Command Diagnostics:
1. **Python Version Check**: Verify Python 3.11 is being used
2. **Pip Version Check**: Confirm pip is working
3. **Directory Verification**: Ensure correct working directory
4. **Requirements File Check**: Verify requirements.txt exists and is readable
5. **Verbose Pip Install**: Show detailed installation process
6. **Python Path Inspection**: Display sys.path for import resolution
7. **Celery Verification**: Test import and show version after installation
8. **Package List**: Confirm celery and django-celery-beat are installed

## Expected Diagnostic Output
This will help identify if the issue is:
- ❓ Python environment isolation
- ❓ Package installation location mismatch
- ❓ Requirements file accessibility
- ❓ Import path resolution
- ❓ Render-specific environment issues

## Next Steps
Based on diagnostic output, we can:
1. Adjust installation flags if needed
2. Modify Python path if necessary
3. Use alternative installation approach
4. Ensure proper environment variables

This debugging will reveal exactly why Celery isn't available at runtime.

🤖 Generated with [Claude Code](https://claude.ai/code)