### PR TITLE
Fix health check endpoint path for Render deployment

### DIFF
--- a/apps/api/core/urls.py
+++ b/apps/api/core/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('healthz/', views.health_check, name='health-check'),
+    path('health/', views.health_check, name='health-check'),
     path('ready/', views.readiness_check, name='readiness-check'),
     path('live/', views.liveness_check, name='liveness-check'),
 ]


### PR DESCRIPTION
## Issue Fixed
- **Health endpoint path**: Changed from /healthz/ to /health/ to match Render deployment requirements

## Changes Made
- Updated core/urls.py to use 'health/' instead of 'healthz/' path
- Maintains existing comprehensive health check functionality
- Still includes database, Redis, and Celery service checks

## Render Integration
- Render expects health checks at /health endpoint
- This enables proper deployment health monitoring
- Supports both startup and runtime health validation

## Endpoint Details
- **URL**: `/health/` (was `/healthz/`)
- **Method**: GET
- **Auth**: No authentication required (AllowAny)
- **Response**: JSON with service status and response time
- **Services Checked**: Database, Redis, Celery

The /ready/ and /live/ endpoints remain unchanged for Kubernetes-style readiness and liveness probes.

🤖 Generated with [Claude Code](https://claude.ai/code)